### PR TITLE
Fix channel send operations to properly handle closed channels

### DIFF
--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -4500,6 +4500,12 @@ ssize_t meshlink_channel_send(meshlink_handle_t *mesh, meshlink_channel_t *chann
 		return -1;
 	}
 
+	if(!channel->c) {
+		/* Channel has been closed, connection is NULL */
+		meshlink_errno = MESHLINK_ENETWORK;
+		return -1;
+	}
+
 	// TODO: more finegrained locking.
 	// Ideally we want to put the data into the UTCP connection's send buffer.
 	// Then, preferably only if there is room in the receiver window,

--- a/src/utcp.c
+++ b/src/utcp.c
@@ -844,8 +844,13 @@ ssize_t utcp_send(struct utcp_connection *c, const void *data, size_t len) {
 	case SYN_SENT:
 	case SYN_RECEIVED:
 	case ESTABLISHED:
-	case CLOSE_WAIT:
 		break;
+
+	case CLOSE_WAIT:
+		/* Remote side has closed, but we haven't closed yet */
+		debug(c, "send() called on connection where remote side has closed\n");
+		errno = EPIPE;
+		return -1;
 
 	case FIN_WAIT_1:
 	case FIN_WAIT_2:


### PR DESCRIPTION
This commit addresses two scenarios where meshlink_channel_send() was not properly handling closed channels:

1. Local channel closure: When meshlink_channel_close() is called locally, it sets channel->c = NULL, but meshlink_channel_send() was not checking for this condition, potentially causing NULL pointer dereference.

2. Remote channel closure: When the remote side closes a channel by sending a FIN packet, the local connection transitions to CLOSE_WAIT state, but utcp_send() was incorrectly allowing data to be sent in this state, violating TCP semantics.

Changes:
- Add NULL check for channel->c in meshlink_channel_send() to prevent crashes when local side closes channel
- Modify utcp_send() to return -1 with errno=EPIPE when called on connections in CLOSE_WAIT state, indicating remote side has closed

This fixes the channels-udp-cornercases test which was failing because the test expected meshlink_channel_send() to return -1 when the remote side had closed the channel, but the function was not properly detecting this condition.

Both fixes are compatible with MeshLink's connection recovery mechanism since they operate at different layers (MeshLink layer vs UTCP layer).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents sends on closed channels and CLOSE_WAIT connections by returning errors (MESHLINK_ENETWORK/EPIPE) instead of proceeding.
> 
> - **Channels (`src/meshlink.c`)**:
>   - `meshlink_channel_send()` now checks `channel->c` and returns `-1` with `meshlink_errno = MESHLINK_ENETWORK` if the channel is closed (NULL), avoiding NULL dereference.
> - **UTCP (`src/utcp.c`)**:
>   - `utcp_send()` rejects sends in `CLOSE_WAIT` state, returning `-1` with `errno = EPIPE` and a debug message, aligning with TCP semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e818515f0cf2e57f866a7c08440c17d1ae0aba8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->