### PR TITLE
Fix iOS/Android port binding by allowing automatic fallback to port 0

### DIFF
--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -1097,8 +1097,11 @@ static bool meshlink_setup(meshlink_handle_t *mesh) {
 	}
 
 	if(check_port(mesh) == 0) {
-		meshlink_errno = MESHLINK_ENETWORK;
-		return false;
+		// On restricted platforms (iOS, Android), check_port() may fail
+		// Allow fallback to port 0 for automatic OS assignment
+		logger(mesh, MESHLINK_DEBUG, "check_port() failed, allowing port 0 fallback");
+		free(mesh->myport);
+		mesh->myport = xstrdup("0");
 	}
 
 	/* Create a node for ourself */

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -1102,6 +1102,7 @@ static bool meshlink_setup(meshlink_handle_t *mesh) {
 		logger(mesh, MESHLINK_DEBUG, "check_port() failed, allowing port 0 fallback");
 		free(mesh->myport);
 		mesh->myport = xstrdup("0");
+		meshlink_errno = MESHLINK_OK;  // Clear error state since fallback succeeds
 	}
 
 	/* Create a node for ourself */


### PR DESCRIPTION
On restricted platforms like iOS and Android, check_port() may fail to bind to ports in the 4096-32768 range due to sandbox restrictions. Previously, this would cause meshlink_open() to fail.

This change adds a fallback mechanism: when check_port() returns 0, we set mesh->myport to "0" to allow automatic OS-assigned ephemeral ports. The existing getsockname() logic in add_listen_sockets() then converts this to the actual assigned port (>32768).

Benefits:
- Mobile devices (iOS/Android) can now use MeshLink without explicit port configuration
- Cloud and IoT devices still use ports <32768 to avoid ephemeral port conflicts
- Port stability is maintained across restarts via config file
- No API changes required - meshPort=0 works for all device types

The fix ensures PORTABLE nodes on mobile platforms automatically get ephemeral ports while BACKBONE/STATIONARY nodes continue using the server port range as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fallback to OS-assigned port (0) if check_port fails during setup, clearing error and enabling binding on restricted platforms (iOS/Android).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f399ad4b33615eed6a67969a9d9c01e931d278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->